### PR TITLE
Relax lower bounds in build-depends

### DIFF
--- a/i18n.cabal
+++ b/i18n.cabal
@@ -25,8 +25,8 @@ library
                      , Data.Text.I18n.Po
                      , Data.Text.I18n.Types
     build-depends:     base >= 4.7 && < 5
-                     , containers >= 0.5.6.2
-                     , filepath >= 1.4.0.0
+                     , containers >= 0.5.5.0
+                     , filepath >= 1.3.0.0
                      , directory >= 1.2.0.0
                      , parsec >= 3.1.9
                      , mtl >= 2.2.1


### PR DESCRIPTION
This makes it possible to build the package with the versions of core packages shipped with GHC 7.8.x.  I've checked that it still builds and the test suite passes.

Note that you don't actually need to release a new version on Hackage for this to be useful, as you can simply modify the package metadata.