### PR TITLE
Replace type aliases with newtypes

### DIFF
--- a/src/Data/Text/I18n.hs
+++ b/src/Data/Text/I18n.hs
@@ -69,7 +69,7 @@ localize l10n loc expression = runIdentity $ runReaderT expression (loc, l10n, N
 --
 -- Examples:
 --
--- >>> let example2 = I18n.withContext (Just "Attack ships on fire off the shoulder of Orion.") example
+-- >>> let example2 = I18n.withContext (Just (Context "Attack ships on fire off the shoulder of Orion.")) example
 -- >>> I18n.localize l10n (I18n.Locale "cym") example2
 -- "Fel dagrau yn y glaw."
 withContext :: Maybe Context -- ^ Context to use
@@ -100,6 +100,6 @@ localizeMsgid l10n loc ctxt msgid = do
   contextual <- Map.lookup ctxt local'
   msgstrs <- Map.lookup msgid contextual
   case listToMaybe msgstrs of
-    Nothing     -> Nothing
-    Just ""     -> Nothing
-    Just msgstr -> Just msgstr
+    Nothing              -> Nothing
+    Just (Msgstr "")     -> Nothing
+    Just (Msgstr msgstr) -> Just msgstr

--- a/src/Data/Text/I18n/Po.hs
+++ b/src/Data/Text/I18n/Po.hs
@@ -168,7 +168,7 @@ msgContext :: Parser (Maybe Context)
 msgContext = try $ option Nothing $ do
   _ <- lexeme (reserved "msgctxt")
   strs <- many1 str
-  return (Just $! mconcat strs)
+  return (Just (Context $! mconcat strs))
 
 msgSingular :: Parser (Msgid, [Msgstr])
 msgSingular = do
@@ -193,13 +193,13 @@ msgidPlural :: Parser Msgstr
 msgidPlural = do
   _ <- lexeme (reserved "msgid_plural")
   strs <- many1 str
-  return $! mconcat strs
+  return $ Msgstr $! mconcat strs
 
 msgstr :: Parser Msgstr
 msgstr = do
   _ <- lexeme (reserved "msgstr")
   strs <- many1 str
-  return $! mconcat strs
+  return $ Msgstr $! mconcat strs
 
 msgstrPlural :: Parser Msgstr
 msgstrPlural = do
@@ -209,7 +209,7 @@ msgstrPlural = do
   _ <- char ']'
   _ <- whiteSpace
   strs <- many1 str
-  return $! mconcat strs
+  return $ Msgstr $! mconcat strs
 
   where
     caseN :: Parser String

--- a/src/Data/Text/I18n/Types.hs
+++ b/src/Data/Text/I18n/Types.hs
@@ -10,14 +10,14 @@
 
 module Data.Text.I18n.Types (
     -- * Type Declarations
-    Context,
+    Context(..),
     CtxMap,
     I18n,
     L10n,
     Locale(..),
     MsgDec(..),
     Msgid(..),
-    Msgstr,
+    Msgstr(..),
     ) where
 
 import           Control.Monad.Identity (Identity)
@@ -29,7 +29,8 @@ import qualified Data.Text              as T
 -- >>> :set -XOverloadedStrings
 --
 -- | Local context.
-type Context = T.Text
+newtype Context = Context T.Text
+  deriving (Eq, Ord)
 
 -- | Mapping from a contexts to translation mappings.
 type CtxMap = Map.Map (Maybe Context) TranslationMap
@@ -56,7 +57,7 @@ newtype Msgid = Msgid T.Text
   deriving (Show, Eq, Ord)
 
 -- | Translated string.
-type Msgstr = T.Text
+newtype Msgstr = Msgstr T.Text
 
 -- | Mapping from identifiers to translations.
 type TranslationMap = Map.Map Msgid [Msgstr]


### PR DESCRIPTION
addresses https://github.com/filib/i18n/issues/4

replaced `Context` and `Msgstr` type aliases with newtypes
